### PR TITLE
Work

### DIFF
--- a/Scripts/Misc/LootPack.cs
+++ b/Scripts/Misc/LootPack.cs
@@ -40,7 +40,7 @@ namespace Server
 				luck = 1200;
 			}
 
-			return (int)(Math.Pow(luck, 1 / 1.55) * 100);
+			return (int)(Math.Pow(luck, 1 / 1.8) * 100);
 		}
 
 		public static int GetLuckChanceForKiller(Mobile dead)
@@ -272,8 +272,8 @@ namespace Server
 				{
 					new LootPackEntry(true, Gold, 100.00, "8d10+100"),
 					new LootPackEntry(false, AosMagicItemsAverageType1, 32.80, 1, 3, 0, 50),
-					new LootPackEntry(false, AosMagicItemsAverageType1, 32.80, 1, 4, 0, 75),
-					new LootPackEntry(false, AosMagicItemsAverageType2, 19.50, 1, 5, 0, 100),
+					new LootPackEntry(false, AosMagicItemsAverageType1, 32.80, 1, 4, 20, 75),
+					new LootPackEntry(false, AosMagicItemsAverageType2, 19.50, 1, 5, 20, 100),
 					new LootPackEntry(false, Instruments, 0.40, 1)
 				});
 
@@ -283,8 +283,8 @@ namespace Server
 				{
 					new LootPackEntry(true, Gold, 100.00, "15d10+225"),
 					new LootPackEntry(false, AosMagicItemsRichType1, 76.30, 1, 4, 0, 75),
-					new LootPackEntry(false, AosMagicItemsRichType1, 76.30, 1, 4, 0, 75),
-					new LootPackEntry(false, AosMagicItemsRichType2, 61.70, 1, 5, 0, 100),
+					new LootPackEntry(false, AosMagicItemsRichType1, 76.30, 1, 4, 30, 75),
+					new LootPackEntry(false, AosMagicItemsRichType2, 61.70, 1, 5, 30, 100),
 					new LootPackEntry(false, Instruments, 1.00, 1)
 				});
 
@@ -294,8 +294,8 @@ namespace Server
 				{
 					new LootPackEntry(true, Gold, 100.00, "3d100+400"),
 					new LootPackEntry(false, AosMagicItemsFilthyRichType1, 79.50, 1, 5, 0, 100),
-					new LootPackEntry(false, AosMagicItemsFilthyRichType1, 79.50, 1, 5, 0, 100),
-					new LootPackEntry(false, AosMagicItemsFilthyRichType2, 77.60, 1, 5, 25, 100),
+					new LootPackEntry(false, AosMagicItemsFilthyRichType1, 79.50, 1, 5, 40, 80),
+					new LootPackEntry(false, AosMagicItemsFilthyRichType2, 77.60, 1, 5, 40, 100),
 					new LootPackEntry(false, Instruments, 2.00, 1)
 				});
 
@@ -304,13 +304,13 @@ namespace Server
 				new[]
 				{
 					new LootPackEntry(true, Gold, 100.00, "6d100+600"),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 25, 100),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 25, 100),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 25, 100),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 25, 100),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 25, 100),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 33, 100),
-					new LootPackEntry(false, Instruments, 2.00, 1)
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 0, 100),
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 0, 100),
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 90.00, 1, 5, 25, 100),
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 90.00, 1, 5, 40, 100),
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 80.00, 1, 5, 50, 100),
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 25.00, 1, 6, 25, 100),
+                    new LootPackEntry(false, Instruments, 2.00, 1)
 				});
 
 		public static readonly LootPack SeSuperBoss =
@@ -318,17 +318,17 @@ namespace Server
 				new[]
 				{
 					new LootPackEntry(true, Gold, 100.00, "10d100+800"),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 25, 100),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 25, 100),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 25, 100),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 25, 100),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 33, 100),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 33, 100),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 33, 100),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 33, 100),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 50, 100),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 50, 100),
-					new LootPackEntry(false, Instruments, 2.00, 1)
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 20, 100),
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 20, 100),
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 90.00, 1, 5, 40, 80),
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 90.00, 1, 5, 40, 80),
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 75.00, 1, 5, 40, 100),
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 60.00, 1, 5, 40, 100),
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 60.00, 1, 5, 40, 100),
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 50.00, 1, 5, 40, 100),
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 40.00, 1, 5, 50, 100),
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 50.00, 1, 6, 25, 100),
+                    new LootPackEntry(false, Instruments, 2.00, 1)
 				});
 		#endregion
 
@@ -343,78 +343,77 @@ namespace Server
 
 		public static readonly LootPack AosMeager =
 			new LootPack(
-				new[]
-				{
-					new LootPackEntry(true, Gold, 100.00, "3d10+20"),
-					new LootPackEntry(false, AosMagicItemsMeagerType1, 1.00, 1, 2, 0, 10),
-					new LootPackEntry(false, AosMagicItemsMeagerType2, 0.20, 1, 5, 0, 90),
-					new LootPackEntry(false, Instruments, 0.10, 1)
-				});
+                new[]
+                {
+                    new LootPackEntry(true, Gold, 100.00, "3d10+20"),
+                    new LootPackEntry(false, AosMagicItemsMeagerType1, 20.40, 1, 2, 0, 50),
+                    new LootPackEntry(false, AosMagicItemsMeagerType2, 10.20, 1, 5, 0, 100),
+                    new LootPackEntry(false, Instruments, 0.10, 1)
+                });
 
-		public static readonly LootPack AosAverage =
+        public static readonly LootPack AosAverage =
 			new LootPack(
 				new[]
 				{
-					new LootPackEntry(true, Gold, 100.00, "5d10+50"),
-					new LootPackEntry(false, AosMagicItemsAverageType1, 5.00, 1, 4, 0, 20),
-					new LootPackEntry(false, AosMagicItemsAverageType1, 2.00, 1, 3, 0, 50),
-					new LootPackEntry(false, AosMagicItemsAverageType2, 0.50, 1, 5, 0, 90),
-					new LootPackEntry(false, Instruments, 0.40, 1)
-				});
+                    new LootPackEntry(true, Gold, 100.00, "5d10+50"),
+                    new LootPackEntry(false, AosMagicItemsAverageType1, 32.80, 1, 3, 0, 50),
+                    new LootPackEntry(false, AosMagicItemsAverageType1, 32.80, 1, 4, 20, 75),
+                    new LootPackEntry(false, AosMagicItemsAverageType2, 19.50, 1, 5, 20, 100),
+                    new LootPackEntry(false, Instruments, 0.40, 1)
+                });
 
 		public static readonly LootPack AosRich =
 			new LootPack(
 				new[]
 				{
-					new LootPackEntry(true, Gold, 100.00, "10d10+150"),
-					new LootPackEntry(false, AosMagicItemsRichType1, 20.00, 1, 4, 0, 40),
-					new LootPackEntry(false, AosMagicItemsRichType1, 10.00, 1, 5, 0, 60),
-					new LootPackEntry(false, AosMagicItemsRichType2, 1.00, 1, 5, 0, 90), new LootPackEntry(false, Instruments, 1.00, 1)
-				});
+                    new LootPackEntry(true, Gold, 100.00, "10d10+150"),
+                    new LootPackEntry(false, AosMagicItemsRichType1, 76.30, 1, 4, 0, 75),
+                    new LootPackEntry(false, AosMagicItemsRichType1, 76.30, 1, 4, 30, 75),
+                    new LootPackEntry(false, AosMagicItemsRichType2, 61.70, 1, 5, 30, 100),
+                    new LootPackEntry(false, Instruments, 1.00, 1)
+                });
 
 		public static readonly LootPack AosFilthyRich =
 			new LootPack(
 				new[]
 				{
-					new LootPackEntry(true, Gold, 100.00, "2d100+200"),
-					new LootPackEntry(false, AosMagicItemsFilthyRichType1, 33.00, 1, 4, 0, 50),
-					new LootPackEntry(false, AosMagicItemsFilthyRichType1, 33.00, 1, 4, 0, 60),
-					new LootPackEntry(false, AosMagicItemsFilthyRichType2, 20.00, 1, 5, 0, 75),
-					new LootPackEntry(false, AosMagicItemsFilthyRichType2, 5.00, 1, 5, 0, 100),
-					new LootPackEntry(false, Instruments, 2.00, 1)
-				});
+                    new LootPackEntry(true, Gold, 100.00, "2d100+200"),
+                    new LootPackEntry(false, AosMagicItemsFilthyRichType1, 79.50, 1, 5, 0, 100),
+                    new LootPackEntry(false, AosMagicItemsFilthyRichType1, 79.50, 1, 5, 40, 80),
+                    new LootPackEntry(false, AosMagicItemsFilthyRichType2, 77.60, 1, 5, 40, 100),
+                    new LootPackEntry(false, Instruments, 2.00, 1)
+                });
 
 		public static readonly LootPack AosUltraRich =
 			new LootPack(
 				new[]
 				{
-					new LootPackEntry(true, Gold, 100.00, "5d100+500"),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 25, 100),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 25, 100),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 25, 100),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 25, 100),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 25, 100),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 35, 100),
-					new LootPackEntry(false, Instruments, 2.00, 1)
-				});
+                    new LootPackEntry(true, Gold, 100.00, "5d100+500"),
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 0, 100),
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 0, 100),
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 90.00, 1, 5, 25, 100),
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 90.00, 1, 5, 40, 100),
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 80.00, 1, 5, 50, 100),
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 25.00, 1, 6, 25, 100),
+                });
 
 		public static readonly LootPack AosSuperBoss =
 			new LootPack(
 				new[]
 				{
-					new LootPackEntry(true, Gold, 100.00, "5d100+500"),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 25, 100),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 25, 100),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 25, 100),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 25, 100),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 33, 100),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 33, 100),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 33, 100),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 33, 100),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 50, 100),
-					new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 50, 100),
-					new LootPackEntry(false, Instruments, 2.00, 1)
-				});
+                    new LootPackEntry(true, Gold, 100.00, "10d100+800"),
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 20, 100),
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 100.00, 1, 5, 20, 100),
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 90.00, 1, 5, 40, 80),
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 90.00, 1, 5, 40, 80),
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 75.00, 1, 5, 40, 100),
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 60.00, 1, 5, 40, 100),
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 60.00, 1, 5, 40, 100),
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 50.00, 1, 5, 40, 100),
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 40.00, 1, 5, 50, 100),
+                    new LootPackEntry(false, AosMagicItemsUltraRich, 50.00, 1, 6, 25, 100),
+                    new LootPackEntry(false, Instruments, 2.00, 1)
+                });
 		#endregion
 
 		#region Pre-AOS definitions

--- a/Scripts/Spells/Base/Spell.cs
+++ b/Scripts/Spells/Base/Spell.cs
@@ -586,7 +586,7 @@ namespace Server.Spells
 				return;
 			}
 
-			if (m_Info.Mantra != null && m_Info.Mantra.Length > 0 && m_Caster.Player)
+			if (m_Info.Mantra != null && m_Info.Mantra.Length > 0)// && m_Caster.Player)
 			{
 				m_Caster.PublicOverheadMessage(MessageType.Spell, m_Caster.SpeechHue, true, m_Info.Mantra, false);
 			}


### PR DESCRIPTION
Reverted the change for extra items based on Luck.

Normalized loot per Era, this might be a horrid idea... but AOS monsters were unlikely to give magic items + those items were crap.

Super packs are almost always distrubuted x2, so every mob that has one has a 2x 50% chance to drop a 6prop item (intensity 50->100%).

Monsters now say spell Mantras.